### PR TITLE
Fix variable for number of transformers in case of reading charging network topology file

### DIFF
--- a/ev2gym/models/ev2gym_env.py
+++ b/ev2gym/models/ev2gym_env.py
@@ -177,6 +177,7 @@ class EV2Gym(gym.Env):
         try:
             with open(self.config['charging_network_topology']) as json_file:
                 self.charging_network_topology = json.load(json_file)
+                self.number_of_transformers = len(self.charging_network_topology)
 
         except FileNotFoundError:
             if not self.config['charging_network_topology'] == 'None':


### PR DESCRIPTION
When the charging network topology file is used to set environment variables, the number of transformers is set based on the value in the config file, e.g., simplePST.yaml. However, this creates an inconsistency in the true number of transformers and leads to the following error.

---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[1], line 12
      9 replay_path = None
     11 # Initialize the environment
---> 12 env = EV2Gym(
     13     config_file=config_file, 
     14     load_from_replay_path=replay_path,
     15     save_replay=False, 
     16     save_plots=True, 
     17     verbose=True, 
     18     render_mode=False,
     19     seed = None
     20 )
     21 state, _ = env.reset(seed=None)
     22 # agent = eMPC_V2G(env,verbose=True)
     23 # agent = V2GProfitMaxOracle(env,verbose=True) # optimal solution
     24 #        or 

File ~/projects/v4grid_optimization/packages/ev2gym_lib/ev2gym/models/ev2gym_env.py:194, in EV2Gym.__init__(self, config_file, load_from_replay_path, replay_save_path, generate_rnd_game, seed, save_replay, save_plots, state_function, reward_function, cost_function, eval_mode, lightweight_plots, empty_ports_at_end_of_simulation, extra_sim_name, verbose, render_mode)
    191 self.grid = load_grid(self)
    193 # Instatiate Transformers
--> 194 self.transformers = load_transformers(self)
    196 # Instatiate Charging Stations
    197 self.charging_stations = load_ev_charger_profiles(self)

File ~/projects/v4grid_optimization/packages/ev2gym_lib/ev2gym/utilities/loaders.py:271, in load_transformers(env)
    265             cs_ids.append(cs_counter)
    266             cs_counter += 1
    267         transformer = Transformer(id=i,
    268                                   env=env,
    269                                   cs_ids=cs_ids,
    270                                   max_power=env.charging_network_topology[tr]['max_power'],
--> 271                                   inflexible_load=inflexible_loads[i, :],
    272                                   solar_power=solar_power[i, :],
    273                                   simulation_length=env.simulation_length
    274                                   )
    276         transformers.append(transformer)
    278 else:
    279     # if env.number_of_transformers > env.cs:
    280     #     raise ValueError(
    281     #         'The number of transformers cannot be greater than the number of charging stations')

IndexError: index 1 is out of bounds for axis 0 with size 1

This PR should fix the issue.