### PR TITLE
Padding zeros in PV and load forecast for state function

### DIFF
--- a/ev2gym/models/transformer.py
+++ b/ev2gym/models/transformer.py
@@ -180,9 +180,9 @@ class Transformer():
             pv_forecast[0] = self.solar_power[step]
 
         if len(load_forecast) < horizon:
-            load_forecast = np.append(load_forecast, np.zeros(horizon-len(load_forecast))
+            load_forecast = np.append(load_forecast, np.ones(horizon-len(load_forecast))
                                       * self.inflexible_load_forecast[-1])
-            pv_forecast = np.append(pv_forecast, np.zeros(horizon-len(pv_forecast))
+            pv_forecast = np.append(pv_forecast, np.ones(horizon-len(pv_forecast))
                                     * self.pv_generation_forecast[-1])
 
         return load_forecast, pv_forecast


### PR DESCRIPTION
When creating environment states for PV and load variables, in case the agent is approaching the terminal state, the forecasted values are being padded with zeros. However, it is probably better to naively set the unknown forecast values to the latest known value. Changing np.zero() to np.one() should achieve this -- probably intended anyway.