### PR TITLE
Fix plot naming inconsistency in ev_city_plot legend

### DIFF
--- a/ev2gym/visuals/plots.py
+++ b/ev2gym/visuals/plots.py
@@ -618,7 +618,7 @@ def ev_city_plot(env):
                    fontsize=28)
         plt.yticks(fontsize=28)
 
-        legend_list = [f'CS {i+1}' for i in tr.cs_ids] + \
+        legend_list = [f'CS {i}' for i in tr.cs_ids] + \
             ['Total Power (kW)'] + \
             ['Power limit (kW)']
 


### PR DESCRIPTION
CS are indexed from 0 in other plots.