### PR TITLE
fix: ensure load and PV forecasts are copied to prevent unintended modifications

### DIFF
--- a/ev2gym/models/transformer.py
+++ b/ev2gym/models/transformer.py
@@ -172,8 +172,8 @@ class Transformer():
 
     def get_load_pv_forecast(self, step, horizon) -> np.array:
 
-        load_forecast = self.inflexible_load_forecast[step:step+horizon]
-        pv_forecast = self.pv_generation_forecast[step:step+horizon]
+        load_forecast = self.inflexible_load_forecast[step:step+horizon].copy()
+        pv_forecast = self.pv_generation_forecast[step:step+horizon].copy()
 
         if step < len(self.inflexible_load_forecast):
             load_forecast[0] = self.inflexible_load[step]


### PR DESCRIPTION
The getter function should not modify objects. Not sure if this modification is inteded and does affect other parts of the code.